### PR TITLE
Fix removal of textStyle mark when any style resets

### DIFF
--- a/packages/extension-text-style/src/text-style.ts
+++ b/packages/extension-text-style/src/text-style.ts
@@ -51,7 +51,7 @@ export const TextStyle = Mark.create<TextStyleOptions>({
     return {
       removeEmptyTextStyle: () => ({ state, commands }) => {
         const attributes = getMarkAttributes(state, this.type)
-        const hasStyles = Object.entries(attributes).every(([, value]) => !!value)
+        const hasStyles = Object.entries(attributes).some(([, value]) => !!value)
 
         if (hasStyles) {
           return true


### PR DESCRIPTION
I built some extensions based on the textStyle extension but whenever I reset a style/attribute, the whole textStyle mark gets removed when there are still other styles defined in the mark.